### PR TITLE
Fix Insights preferences on supported GNOME versions

### DIFF
--- a/prefs/insightsPage.js
+++ b/prefs/insightsPage.js
@@ -251,7 +251,10 @@ export function buildInsightsPage(settings) {
     stSummaryGroup.add(stBestRow);
     stSummaryGroup.add(stDaysRow);
 
-    const clearStBtn = new Adw.ButtonRow({ title: 'Clear Screen Time Data' });
+    const clearStBtn = new Adw.ActionRow({
+        title: 'Clear Screen Time Data',
+        activatable: true,
+    });
     clearStBtn.connect('activated', () => {
         const dialog = new Adw.AlertDialog({
             heading: 'Clear All Screen Time Data?',
@@ -276,6 +279,9 @@ export function buildInsightsPage(settings) {
         'No screen time data yet',
         'Screen time tracking will appear here once the Screen Time widget is active on your desktop.'
     );
+    const stEmptyGroup = new Adw.PreferencesGroup();
+    stEmptyGroup.add(stEmptyBox);
+    page.add(stEmptyGroup);
 
     const stDayGroup = new Adw.PreferencesGroup({
         title: 'Day Detail',
@@ -331,6 +337,9 @@ export function buildInsightsPage(settings) {
         'No mood data yet',
         'Log your first mood in the Mood Logger widget to start tracking how you feel.'
     );
+    const moodEmptyGroup = new Adw.PreferencesGroup();
+    moodEmptyGroup.add(moodEmptyBox);
+    page.add(moodEmptyGroup);
 
     const moodDayGroup = new Adw.PreferencesGroup({
         title: 'Day Detail',
@@ -381,7 +390,10 @@ export function buildInsightsPage(settings) {
         title: 'Export Data',
         description: 'Save your insights data to a JSON file.',
     });
-    const exportStBtn = new Adw.ButtonRow({ title: 'Export Screen Time Data' });
+    const exportStBtn = new Adw.ActionRow({
+        title: 'Export Screen Time Data',
+        activatable: true,
+    });
     exportStBtn.connect('activated', () => {
         const exportData = buildScreenTimeExportData(stAvailableDates);
         const json = JSON.stringify(exportData, null, 2);
@@ -390,7 +402,10 @@ export function buildInsightsPage(settings) {
     });
     exportGroup.add(exportStBtn);
 
-    const exportMoodBtn = new Adw.ButtonRow({ title: 'Export Mood Data' });
+    const exportMoodBtn = new Adw.ActionRow({
+        title: 'Export Mood Data',
+        activatable: true,
+    });
     exportMoodBtn.connect('activated', () => {
         const exportData = buildMoodExportData(moodAvailableDates);
         const json = JSON.stringify(exportData, null, 2);
@@ -677,11 +692,7 @@ export function buildInsightsPage(settings) {
         }
 
         const hasStData = stAvailableDates.length > 0;
-        if (hasStData) {
-            if (stEmptyBox.get_parent()) page.remove(stEmptyBox);
-        } else {
-            if (!stEmptyBox.get_parent()) page.add(stEmptyBox);
-        }
+        stEmptyGroup.set_visible(!hasStData);
         stDayGroup.set_visible(hasStData);
 
         refreshStSummary();
@@ -697,11 +708,7 @@ export function buildInsightsPage(settings) {
         }
 
         const hasMoodData = moodAvailableDates.length > 0;
-        if (hasMoodData) {
-            if (moodEmptyBox.get_parent()) page.remove(moodEmptyBox);
-        } else {
-            if (!moodEmptyBox.get_parent()) page.add(moodEmptyBox);
-        }
+        moodEmptyGroup.set_visible(!hasMoodData);
         moodDayGroup.set_visible(hasMoodData);
 
         refreshMoodSummary();


### PR DESCRIPTION
## Summary

- Replace `Adw.ButtonRow` with activatable `Adw.ActionRow` for compatibility with libadwaita 1.5.
- Wrap the screen-time and mood empty states in dedicated `Adw.PreferencesGroup` containers.
- Toggle empty-state visibility without dynamically reparenting widgets.

## Problem

GNOME 46 ships libadwaita 1.5, where `Adw.ButtonRow` is unavailable. This caused the Insights preferences page to fail during construction.

After resolving that incompatibility, the empty state exposed another error: `Adw.PreferencesPage.add()` only accepts `Adw.PreferencesGroup`, but the page attempted to add `Gtk.Box` widgets directly.

## Testing

Tested on:

- Zorin OS
- GNOME Shell 46.0
- Wayland
- libadwaita 1.5

Verified:

- Preferences opens without constructor or widget-conversion errors.
- Empty Screen Time and Mood states render correctly.
- The Clear Screen Time confirmation dialog opens.
- Both Export save dialogs open.
- `node --check prefs/insightsPage.js` passes.

GNOME 47–50 were not tested directly.

Fixes #2
